### PR TITLE
detect endianess at runtime

### DIFF
--- a/src/main/main/endianIO.c
+++ b/src/main/main/endianIO.c
@@ -3,17 +3,11 @@
 
 #include "sgrid.h"
 
-/* About binary formats:
-   There exists /usr/include/endian.h, but how standard is this?
-   also see /usr/include/byteswap.h, which does not do 8 bytes for non-gcc?
-   see include/bits/byteswap.h for gcc/x86 optimized code
-*/
-#include <endian.h>
-#if  __BYTE_ORDER == __LITTLE_ENDIAN
-#define BYTE_ORDER_LITTLE 1
-#else
-#define BYTE_ORDER_LITTLE 0
-#endif
+static inline char get_byte_order(void) {
+  const short order = 1;
+  return *(char*)&order;
+}
+#define BYTE_ORDER_LITTLE get_byte_order()
 
 
 /* use fwrite to write an array of doubles to a file in little endian format */

--- a/src/utility/output/VTK_out.c
+++ b/src/utility/output/VTK_out.c
@@ -11,17 +11,12 @@
    The VTK lagacy data format used here is by default big endian binary data.
    This used to be the default on "workstations", while x86 "PCs"
    typically use little endian.
-
-   There exists /usr/include/endian.h, but how standard is this?
-   also see /usr/include/byteswap.h, which does not do 8 bytes for non-gcc?
-   see include/bits/byteswap.h for gcc/x86 optimized code
 */
-#include <endian.h>
-#if  __BYTE_ORDER == __LITTLE_ENDIAN
-#define BYTE_ORDER_LITTLE 1
-#else
-#define BYTE_ORDER_LITTLE 0
-#endif
+static inline char get_byte_order(void) {
+  const short order = 1;
+  return *(char*)&order;
+}
+#define BYTE_ORDER_LITTLE get_byte_order()
 
 
 /* in 3d and 2d it usually comes down to this: write numbers 


### PR DESCRIPTION
Most likely the code itself should be adjusted a bit to more nicely mesh with other code in SGRID (eg style is different, duplicates a `static inline` function), but it shows how this can be done.

Change is identical to patch applied in ET in pull request https://github.com/EinsteinToolkit/ExternalLibraries-SGRID/pull/1